### PR TITLE
Update install command for winget

### DIFF
--- a/pages/download.tsx
+++ b/pages/download.tsx
@@ -65,7 +65,7 @@ const Download = (props: Props) => {
         />
         <CodeBlockSection
             title='Winget (Windows)'
-            text={`winget install ferdium`}
+            text={`# to install Beta pre-releases:\nwinget install ferdium-beta\n# for nightly pre-releases:\nwinget install ferdium-nightly`}
         />
         <CodeBlockSection
           title='Snap (Ubuntu linux and derivatives)'


### PR DESCRIPTION
On Windows, installing through winget is now split between the different channels as follows:
- the id `Ferdium.Ferdium` with moniker `ferdium` is reserved for stable releases;
- beta releases go under `Ferdium.Ferdium.Beta` with the moniker `ferdium-beta`
- nigthly releases go under `Ferdium.Ferdium.Nightly` with the moniker `ferdium-nightly`.