### PR TITLE
Similar to winget, provide instructions for stable/beta/nightly for other package managers

### DIFF
--- a/pages/download.tsx
+++ b/pages/download.tsx
@@ -305,18 +305,23 @@ const Download = (props: Props) => {
           text={`yay -S ferdium-bin\n// or, to compile yourself\nyay -S ferdium`}
         />
         <CodeBlockSection title='Flatpak' text={`flatpak install flathub org.ferdium.Ferdium`} />
+        {
+          // TODO: Update Flatpak with beta version when available
+        }
         <CodeBlockSection
           title='Homebrew (macOS)'
           text={`brew tap ferdium/ferdium\n# to install the last stable release:\nbrew install ferdium\n# or for Beta pre-releases:\nbrew install ferdium-beta\n# or for nightly pre-releases:\nbrew install ferdium-nightly`}
         />
         <CodeBlockSection
           title='Scoop (Windows)'
-          text={`scoop bucket add versions\n# to install the last stable release:\nscoop install ferdium\n# or for nightly pre-releases:\nscoop install ferdium-nightly`}
+          text={`scoop bucket add versions\n# to install the last nightly pre-releases:\nscoop install ferdium-nightly`}
         />
-
+        { 
+          // TODO: Update scoop installer to include stable version when bucket will be ready
+        } 
         <CodeBlockSection
             title='Chocolatey (Windows)'
-            text={`# to install the last stable release:\nchoco install ferdium --pre\n# or for nightly pre-releases:\nchoco install ferdium --pre`}
+            text={`# to install the last stable release:\nchoco install ferdium \n# or for beta pre-releases (when available):\nchoco install ferdium --pre`}
         />
         <CodeBlockSection
             title='Winget (Windows)'

--- a/pages/download.tsx
+++ b/pages/download.tsx
@@ -307,16 +307,16 @@ const Download = (props: Props) => {
         <CodeBlockSection title='Flatpak' text={`flatpak install flathub org.ferdium.Ferdium`} />
         <CodeBlockSection
           title='Homebrew (macOS)'
-          text={`brew tap ferdium/ferdium\nbrew install ferdium`}
+          text={`brew tap ferdium/ferdium\n# to install the last stable release:\nbrew install ferdium\n# or for Beta pre-releases:\nbrew install ferdium-beta\n# or for nightly pre-releases:\nbrew install ferdium-nightly`}
         />
         <CodeBlockSection
           title='Scoop (Windows)'
-          text={`scoop bucket add versions\nscoop install ferdium-nightly`}
+          text={`scoop bucket add versions\n# to install the last stable release:\nscoop install ferdium\n# or for nightly pre-releases:\nscoop install ferdium-nightly`}
         />
 
         <CodeBlockSection
             title='Chocolatey (Windows)'
-            text={`choco install ferdium --pre`}
+            text={`# to install the last stable release:\nchoco install ferdium --pre\n# or for nightly pre-releases:\nchoco install ferdium --pre`}
         />
         <CodeBlockSection
             title='Winget (Windows)'


### PR DESCRIPTION
Since we publish nightlies/beta/stable - we should probably provide instructions for installing any of them. The instructions for the `winget` package manager are already present on the website. This PR replicates the same for homebrew, scoop, etc

Note: I have tested only the homebrew steps. I would request others to test the other package managers and then approve this PR