### PR TITLE
chore: change install instructions for snap channel

### DIFF
--- a/pages/download.tsx
+++ b/pages/download.tsx
@@ -23,7 +23,9 @@ type releaseObject = {
 };
 
 const Download = (props: Props) => {
-  const [latestReleases, setLatestReleases] = useState<Array<releaseObject>>([]);
+  const [latestReleases, setLatestReleases] = useState<Array<releaseObject>>(
+    []
+  );
   const [currentTab, setCurrentTab] = useState<string>();
   const [primaryDownloadUrl, setPrimaryDownloadUrl] = useState<releaseObject>();
   const [isGettingRelease, setIsGettingRelease] = useState(false);
@@ -38,7 +40,10 @@ const Download = (props: Props) => {
     const cache = JSON.parse(localStorage.getItem("cachedRelease") ?? "{}");
 
     // If we have a cached release and it hasn't expired, use it.
-    if (cache.cacheExpires && parseInt(cache.cacheExpires) > new Date().getTime()) {
+    if (
+      cache.cacheExpires &&
+      parseInt(cache.cacheExpires) > new Date().getTime()
+    ) {
       return cache.release;
     }
 
@@ -101,22 +106,27 @@ const Download = (props: Props) => {
         return castAsset;
       })
       .filter(
-        (asset: releaseObject) => !asset.name.includes("yml") && !asset.name.includes("blockmap")
+        (asset: releaseObject) =>
+          !asset.name.includes("yml") && !asset.name.includes("blockmap")
       );
 
-    const userOS = navigator.userAgent.match(/Mac|Win|Linux/g)?.[0].toLowerCase() || "win";
+    const userOS =
+      navigator.userAgent.match(/Mac|Win|Linux/g)?.[0].toLowerCase() || "win";
     switch (true) {
       case userOS.includes("linux"):
         setCurrentTab("linux");
         setPrimaryDownloadUrl(
-          filteredResponse.find((asset: releaseObject) => asset.name.includes("AppImage"))
+          filteredResponse.find((asset: releaseObject) =>
+            asset.name.includes("AppImage")
+          )
         );
         break;
       case userOS.includes("mac"):
         setCurrentTab("mac");
         setPrimaryDownloadUrl(
           filteredResponse.find(
-            (asset: releaseObject) => asset.name.includes("dmg") && asset.name.includes("x64")
+            (asset: releaseObject) =>
+              asset.name.includes("dmg") && asset.name.includes("x64")
           )
         );
         break;
@@ -144,7 +154,7 @@ const Download = (props: Props) => {
       links = (
         <PlatformDownloads
           grid
-          gridTemplate='linux'
+          gridTemplate="linux"
           gridTemplateArray={["deb", "rpm", "appimage", "freebsd", "tar"]}
           downloadTypes={[
             {
@@ -156,25 +166,33 @@ const Download = (props: Props) => {
             {
               title: "RPM",
               link: {
-                ...latestReleases.find((asset: releaseObject) => asset.name.includes("rpm")),
+                ...latestReleases.find((asset: releaseObject) =>
+                  asset.name.includes("rpm")
+                ),
               },
             },
             {
               title: "AppImage",
               link: {
-                ...latestReleases.find((asset: releaseObject) => asset.name.includes("AppImage")),
+                ...latestReleases.find((asset: releaseObject) =>
+                  asset.name.includes("AppImage")
+                ),
               },
             },
             {
               title: "FreeBSD",
               link: {
-                ...latestReleases.find((asset: releaseObject) => asset.name.includes("freebsd")),
+                ...latestReleases.find((asset: releaseObject) =>
+                  asset.name.includes("freebsd")
+                ),
               },
             },
             {
               title: "Tar",
               link: {
-                ...latestReleases.find((asset: releaseObject) => asset.name.includes("tar")),
+                ...latestReleases.find((asset: releaseObject) =>
+                  asset.name.includes("tar")
+                ),
               },
             },
           ]}
@@ -190,7 +208,8 @@ const Download = (props: Props) => {
               multipleLinks: latestReleases
                 .filter(
                   (asset: releaseObject) =>
-                    asset.name.includes("exe") && !asset.name.includes("Portable")
+                    asset.name.includes("exe") &&
+                    !asset.name.includes("Portable")
                 )
                 .reverse(),
             },
@@ -199,7 +218,8 @@ const Download = (props: Props) => {
               multipleLinks: latestReleases
                 .filter(
                   (asset: releaseObject) =>
-                    asset.name.includes("exe") && asset.name.includes("Portable")
+                    asset.name.includes("exe") &&
+                    asset.name.includes("Portable")
                 )
                 .reverse(),
             },
@@ -233,26 +253,27 @@ const Download = (props: Props) => {
   }
   return (
     <Layout>
-      <Head title='Ferdium | Download' />
+      <Head title="Ferdium | Download" />
       {fallback && (
         <Section>
           <h1>Download</h1>
           <div className={styles.copy}>
             <p>
-              Something went wrong when getting the links to the latest Ferdium release. Try again
-              later or follow the link below to download the latest nightly release of Ferdium from
-              our GitHub Releases.{" "}
+              Something went wrong when getting the links to the latest Ferdium
+              release. Try again later or follow the link below to download the
+              latest nightly release of Ferdium from our GitHub Releases.{" "}
             </p>
 
             <p>
-              Once there click &quot;Assets&quot; and choose the version for your platform (check
-              the
-              <Link href='/faq'> FAQ </Link> if you are unsure which one to get)! We currently have
-              releases for macOS, Windows, Linux (AppImage and DEB) and FreeBSD.
+              Once there click &quot;Assets&quot; and choose the version for
+              your platform (check the
+              <Link href="/faq"> FAQ </Link> if you are unsure which one to
+              get)! We currently have releases for macOS, Windows, Linux
+              (AppImage and DEB) and FreeBSD.
             </p>
           </div>
-          <ExternalLink href='https://github.com/ferdium/ferdium-app/releases/latest'>
-            <Button cta size='huge'>
+          <ExternalLink href="https://github.com/ferdium/ferdium-app/releases/latest">
+            <Button cta size="huge">
               Download from GitHub
             </Button>
           </ExternalLink>
@@ -263,12 +284,14 @@ const Download = (props: Props) => {
         <>
           <Section>
             <h1>Download</h1>
-            <p className={styles.copy}>Find the installer for your OS below to install Ferdium!</p>
+            <p className={styles.copy}>
+              Find the installer for your OS below to install Ferdium!
+            </p>
             {!primaryDownloadUrl || isGettingRelease ? (
               <Loader />
             ) : (
               <ExternalLink href={primaryDownloadUrl?.browser_download_url}>
-                <Button cta size='huge'>
+                <Button cta size="huge">
                   Download
                 </Button>
               </ExternalLink>
@@ -295,41 +318,44 @@ const Download = (props: Props) => {
       <Section>
         <h2>Using your OS&apos;s package manager</h2>
         <p className={styles.copy}>
-          Alternatively, you can use the package manager of your OS to install Ferdium. Use one of
-          the CLI commands below depending on your OS to install the latest binary release of
-          Ferdium. Some package managers (like AUR) also allow you to build the source release
-          yourself.
+          Alternatively, you can use the package manager of your OS to install
+          Ferdium. Use one of the CLI commands below depending on your OS to
+          install the latest binary release of Ferdium. Some package managers
+          (like AUR) also allow you to build the source release yourself.
         </p>
         <CodeBlockSection
-          title='AUR (Arch Linux and derivatives)'
-          text={`yay -S ferdium-bin\n// or, to compile yourself\nyay -S ferdium`}
+          title="AUR (Arch Linux and derivatives)"
+          text={`yay -S ferdium-bin\n# or, to compile yourself\nyay -S ferdium`}
         />
-        <CodeBlockSection title='Flatpak' text={`flatpak install flathub org.ferdium.Ferdium`} />
+        <CodeBlockSection
+          title="Flatpak"
+          text={`flatpak install flathub org.ferdium.Ferdium`}
+        />
         {
           // TODO: Update Flatpak with beta version when available
         }
         <CodeBlockSection
-          title='Homebrew (macOS)'
-          text={`brew tap ferdium/ferdium\n# to install the last stable release:\nbrew install ferdium\n# or for Beta pre-releases:\nbrew install ferdium-beta\n# or for nightly pre-releases:\nbrew install ferdium-nightly`}
+          title="Homebrew (macOS)"
+          text={`brew tap ferdium/ferdium\n# to install the latest stable release:\nbrew install ferdium\n# or for beta pre-releases:\nbrew install ferdium-beta\n# or for nightly pre-releases:\nbrew install ferdium-nightly`}
         />
         <CodeBlockSection
-          title='Scoop (Windows)'
-          text={`scoop bucket add versions\n# to install the last nightly pre-releases:\nscoop install ferdium-nightly`}
+          title="Scoop (Windows)"
+          text={`scoop bucket add versions\n# to install the latest nightly pre-releases:\nscoop install ferdium-nightly`}
         />
-        { 
+        {
           // TODO: Update scoop installer to include stable version when bucket will be ready
-        } 
+        }
         <CodeBlockSection
-            title='Chocolatey (Windows)'
-            text={`# to install the last stable release:\nchoco install ferdium \n# or for beta pre-releases (when available):\nchoco install ferdium --pre`}
+          title="Chocolatey (Windows)"
+          text={`# to install the latest stable release:\nchoco install ferdium \n# or for beta pre-releases:\nchoco install ferdium --pre`}
         />
         <CodeBlockSection
-            title='Winget (Windows)'
-            text={`# to install the last stable release:\nwinget install ferdium\n# or for Beta pre-releases:\nwinget install ferdium-beta\n# or for nightly pre-releases:\nwinget install ferdium-nightly`}
+          title="Winget (Windows)"
+          text={`# to install the latest stable release:\nwinget install ferdium\n# or for beta pre-releases:\nwinget install ferdium-beta\n# or for nightly pre-releases:\nwinget install ferdium-nightly`}
         />
         <CodeBlockSection
-          title='Snap (Ubuntu linux and derivatives)'
-          text={`snap install ferdium\nsnap connect ferdium:camera\nsnap connect ferdium:audio-record`}
+          title="Snap (Ubuntu linux and derivatives)"
+          text={`# to install the latest stable release:\nsnap install ferdium\n# or for beta pre-releases:\nsnap install ferdium --beta\n# or for nightly pre-releases:\nsnap install ferdium --edge\n# connect additional interfaces:\nsnap connect ferdium:camera\nsnap connect ferdium:audio-record`}
         />
       </Section>
     </Layout>

--- a/pages/download.tsx
+++ b/pages/download.tsx
@@ -329,7 +329,7 @@ const Download = (props: Props) => {
         />
         <CodeBlockSection
           title='Snap (Ubuntu linux and derivatives)'
-          text={`snap install --edge ferdium\nsnap connect ferdium:camera\nsnap connect ferdium:audio-record`}
+          text={`snap install ferdium\nsnap connect ferdium:camera\nsnap connect ferdium:audio-record`}
         />
       </Section>
     </Layout>


### PR DESCRIPTION
## Changes
- update `download.tsx` to recommend snap stable, beta and edge channels instead of edge channel only

## Motivation
Closes https://github.com/ferdium/ferdium-app/issues/1450

## Screenshots
![Screenshot from 2023-11-23 06-28-18](https://github.com/ferdium/ferdium-website/assets/16797721/7f56a3c8-72ff-48d9-b2e6-4a45e7776c46)


